### PR TITLE
[Rules RBAC] Enables bulk_actions APIs to return proper error response codes

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_fill_gaps_by_rule_ids/bulk_fill_gaps_by_rule_ids.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_fill_gaps_by_rule_ids/bulk_fill_gaps_by_rule_ids.ts
@@ -15,7 +15,7 @@ import {
   BulkGapsFillStep,
   BulkFillGapsScheduleResult,
 } from './types';
-import { logProcessedAsAuditEvent, toBulkGapFillError } from './utils';
+import { logProcessedAsAuditEvent, toBulkOperationError } from './utils';
 import { AlertingAuthorizationEntity, WriteOperations } from '../../../../authorization';
 import { batchBackfillRuleGaps } from './batch_backfill_rule_gaps';
 import { validateBackfillSchedule } from '../../../../../common/lib';
@@ -67,7 +67,7 @@ export const bulkFillGapsByRuleIds = async (
     } catch (error) {
       rulesBatch.forEach((rule) => {
         logProcessedAsAuditEvent(context, { id: rule.id, name: rule.name }, error);
-        errored.push(toBulkGapFillError(rule, BulkGapsFillStep.ACCESS_VALIDATION, error));
+        errored.push(toBulkOperationError(rule, BulkGapsFillStep.ACCESS_VALIDATION, error));
         return;
       });
     }

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_fill_gaps_by_rule_ids/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_fill_gaps_by_rule_ids/types.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { BulkOperationError } from '../../../../rules_client';
+
 export enum BulkGapsFillStep {
   ACCESS_VALIDATION = 'ACCESS_VALIDATION',
   SCHEDULING = 'SCHEDULING',
@@ -16,13 +18,8 @@ export enum BulkFillGapsScheduleResult {
   ERRORED = 'ERRORED',
 }
 
-export interface BulkGapFillingErroredRule {
-  rule: {
-    id: string;
-    name: string;
-  };
+export interface BulkGapFillError extends BulkOperationError {
   step: BulkGapsFillStep;
-  errorMessage: string;
 }
 
 interface RuleToBackfill {
@@ -48,5 +45,5 @@ export interface BulkFillGapsByRuleIdsOptions {
 export interface BulkFillGapsByRuleIdsResult {
   backfilled: RuleToBackfill[];
   skipped: RuleToBackfill[];
-  errored: BulkGapFillingErroredRule[];
+  errored: BulkGapFillError[];
 }

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_fill_gaps_by_rule_ids/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_fill_gaps_by_rule_ids/types.ts
@@ -18,10 +18,6 @@ export enum BulkFillGapsScheduleResult {
   ERRORED = 'ERRORED',
 }
 
-export interface BulkGapFillError extends BulkOperationError {
-  step: BulkGapsFillStep;
-}
-
 interface RuleToBackfill {
   id: string;
   name: string;
@@ -45,5 +41,5 @@ export interface BulkFillGapsByRuleIdsOptions {
 export interface BulkFillGapsByRuleIdsResult {
   backfilled: RuleToBackfill[];
   skipped: RuleToBackfill[];
-  errored: BulkGapFillError[];
+  errored: BulkOperationError[];
 }

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_fill_gaps_by_rule_ids/utils.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_fill_gaps_by_rule_ids/utils.ts
@@ -6,17 +6,17 @@
  */
 
 import { isBoom } from '@hapi/boom';
-import { type BulkGapFillError, BulkGapsFillStep } from './types';
-import type { RulesClientContext } from '../../../../rules_client';
+import { BulkGapsFillStep } from './types';
+import type { BulkOperationError, RulesClientContext } from '../../../../rules_client';
 import type { RuleAuditEventParams } from '../../../../rules_client/common/audit_events';
 import { ruleAuditEvent, RuleAuditAction } from '../../../../rules_client/common/audit_events';
 import { RULE_SAVED_OBJECT_TYPE } from '../../../../saved_objects';
 
-export const toBulkGapFillError = (
+export const toBulkOperationError = (
   rule: { id: string; name: string },
   step: BulkGapsFillStep,
   error: Error
-): BulkGapFillError => {
+): BulkOperationError => {
   let fallbackMessage: string;
 
   const status = isBoom(error) ? error.output.statusCode : 500;
@@ -30,14 +30,14 @@ export const toBulkGapFillError = (
       fallbackMessage = 'Error validating user access to the rule';
       break;
   }
+
   return {
     rule: {
       id: rule.id,
       name: rule.name,
     },
-    step,
     status,
-    message: message ?? fallbackMessage,
+    message: `${step} - ${message ?? fallbackMessage}`,
   };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/revert_prebuilt_rule/get_concurrrency_errors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/revert_prebuilt_rule/get_concurrrency_errors.ts
@@ -6,7 +6,7 @@
  */
 
 import type { RuleResponse } from '../../../../../../common/api/detection_engine';
-import type { BulkActionError } from '../../../rule_management/api/rules/bulk_actions/bulk_actions_response';
+import type { BulkActionError } from '../../../rule_management/api/rules/bulk_actions/utils';
 import { createBulkActionError } from '../../../rule_management/utils/utils';
 
 export const getConcurrencyErrors = (

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/revert_prebuilt_rule/revert_prebuilt_rule_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/revert_prebuilt_rule/revert_prebuilt_rule_handler.ts
@@ -17,10 +17,8 @@ import {
 import type { SecuritySolutionRequestHandlerContext } from '../../../../../types';
 import { buildSiemResponse } from '../../../routes/utils';
 import { createPrebuiltRuleAssetsClient } from '../../logic/rule_assets/prebuilt_rule_assets_client';
-import {
-  normalizeErrorResponse,
-  type BulkActionError,
-} from '../../../rule_management/api/rules/bulk_actions/bulk_actions_response';
+import type { BulkActionError } from '../../../rule_management/api/rules/bulk_actions/utils';
+import { normalizeErrorResponse } from '../../../rule_management/api/rules/bulk_actions/bulk_actions_response';
 import type { RuleTriad } from '../../model/rule_groups/get_rule_groups';
 import { zipRuleVersions } from '../../logic/rule_versions/zip_rule_versions';
 import { revertPrebuiltRules } from '../../logic/rule_objects/revert_prebuilt_rules';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_actions_response.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_actions_response.test.ts
@@ -250,5 +250,81 @@ describe('buildBulkResponse', () => {
         })
       );
     });
+
+    describe('with bulk operation errors', () => {
+      it('returns a 403 error in the expected format when the bulk operation error is 403', () => {
+        const error = {
+          rule: { id: 'mockedId', name: 'mockedName' },
+          message: 'You do not have permission to perform this action',
+          status: 403,
+        };
+
+        buildBulkResponse(mockResponseFactory, {
+          bulkAction: BulkActionTypeEnum.duplicate,
+          isDryRun: false,
+          errors: [error],
+          updated: [],
+          created: [],
+          deleted: [],
+          skipped: [],
+        });
+
+        expect(mockResponseFactory.custom).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              message: 'Bulk edit failed',
+              status_code: 403,
+              attributes: expect.objectContaining({
+                errors: [
+                  expect.objectContaining({
+                    message: 'You do not have permission to perform this action',
+                    status_code: 403,
+                    rules: [{ id: 'mockedId', name: 'mockedName' }],
+                  }),
+                ],
+              }),
+            }),
+            statusCode: 403,
+          })
+        );
+      });
+
+      it('returns a 500 error in the expected format when the bulk operation error is 500', () => {
+        const error = {
+          rule: { id: 'mockedId', name: 'mockedName' },
+          message: 'Something went wrong',
+          status: 500,
+        };
+
+        buildBulkResponse(mockResponseFactory, {
+          bulkAction: BulkActionTypeEnum.duplicate,
+          isDryRun: false,
+          errors: [error],
+          updated: [],
+          created: [],
+          deleted: [],
+          skipped: [],
+        });
+
+        expect(mockResponseFactory.custom).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              message: 'Bulk edit failed',
+              status_code: 500,
+              attributes: expect.objectContaining({
+                errors: [
+                  expect.objectContaining({
+                    message: 'Something went wrong',
+                    status_code: 500,
+                    rules: [{ id: 'mockedId', name: 'mockedName' }],
+                  }),
+                ],
+              }),
+            }),
+            statusCode: 500,
+          })
+        );
+      });
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_actions_response.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_actions_response.test.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import { httpServerMock } from '@kbn/core/server/mocks';
+
+import { buildBulkResponse } from './bulk_actions_response';
+import { BulkActionTypeEnum } from '../../../../../../../common/api/detection_engine';
+
+describe('buildBulkResponse', () => {
+  let mockResponseFactory: ReturnType<typeof httpServerMock.createResponseFactory>;
+  beforeEach(() => {
+    mockResponseFactory = httpServerMock.createResponseFactory();
+  });
+
+  it('builds a bulk response with the correct structure', () => {
+    buildBulkResponse(mockResponseFactory, {
+      bulkAction: BulkActionTypeEnum.duplicate,
+      isDryRun: false,
+      errors: [],
+      updated: [],
+      created: [],
+      deleted: [],
+      skipped: [],
+    });
+
+    expect(mockResponseFactory.ok).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          success: true,
+          rules_count: 0,
+          attributes: expect.objectContaining({
+            results: expect.objectContaining({
+              updated: [],
+              created: [],
+              deleted: [],
+              skipped: [],
+            }),
+            summary: expect.objectContaining({
+              failed: 0,
+              succeeded: 0,
+              skipped: 0,
+              total: 0,
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  describe('responses with errors', () => {
+    it('returns error messages in the expected format', () => {
+      const errorOutcome = {
+        item: 'N/A',
+        error: new Error('Something went wrong'),
+      };
+
+      buildBulkResponse(mockResponseFactory, {
+        bulkAction: BulkActionTypeEnum.duplicate,
+        isDryRun: false,
+        errors: [errorOutcome],
+        updated: [],
+        created: [],
+        deleted: [],
+        skipped: [],
+      });
+
+      expect(mockResponseFactory.custom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            message: 'Bulk edit failed',
+            status_code: 500,
+            attributes: expect.objectContaining({
+              errors: [
+                expect.objectContaining({
+                  message: 'Something went wrong',
+                  status_code: 500,
+                  rules: [{ id: 'N/A' }],
+                }),
+              ],
+            }),
+          }),
+          statusCode: 500,
+        })
+      );
+    });
+
+    it('responds with a status code of 403 if the error is a 403', () => {
+      const errorOutcome = {
+        item: 'N/A',
+        error: Boom.forbidden('You do not have permission to perform this action'),
+      };
+
+      buildBulkResponse(mockResponseFactory, {
+        bulkAction: BulkActionTypeEnum.duplicate,
+        isDryRun: false,
+        errors: [errorOutcome],
+        updated: [],
+        created: [],
+        deleted: [],
+        skipped: [],
+      });
+
+      expect(mockResponseFactory.custom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            message: 'Bulk edit failed',
+            status_code: 403,
+            attributes: expect.objectContaining({
+              errors: [
+                expect.objectContaining({
+                  message: 'You do not have permission to perform this action',
+                  status_code: 403,
+                  rules: [{ id: 'N/A' }],
+                }),
+              ],
+            }),
+          }),
+          statusCode: 403,
+        })
+      );
+    });
+
+    it('responds with a status code of 500 if there is a 500 error', () => {
+      const errorOutcome = {
+        item: 'N/A',
+        error: Boom.internal('Something went wrong'),
+      };
+
+      buildBulkResponse(mockResponseFactory, {
+        bulkAction: BulkActionTypeEnum.duplicate,
+        isDryRun: false,
+        errors: [errorOutcome],
+        updated: [],
+        created: [],
+        deleted: [],
+        skipped: [],
+      });
+
+      expect(mockResponseFactory.custom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            message: 'Bulk edit failed',
+            status_code: 500,
+            attributes: expect.objectContaining({
+              errors: [
+                expect.objectContaining({
+                  message: 'An internal server error occurred',
+                  status_code: 500,
+                  rules: [{ id: 'N/A' }],
+                }),
+              ],
+            }),
+          }),
+          statusCode: 500,
+        })
+      );
+    });
+
+    it('responds with the highest status code if there are multiple errors of the same tier of status code', () => {
+      buildBulkResponse(mockResponseFactory, {
+        bulkAction: BulkActionTypeEnum.duplicate,
+        isDryRun: false,
+        errors: [
+          {
+            item: 'mocked',
+            error: Boom.forbidden('You do not have permission to perform this action'),
+          },
+          {
+            item: 'mocked2',
+            error: Boom.badRequest('User error'),
+          },
+        ],
+        updated: [],
+        created: [],
+        deleted: [],
+        skipped: [],
+      });
+
+      expect(mockResponseFactory.custom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            message: 'Bulk edit failed',
+            status_code: 403,
+            attributes: expect.objectContaining({
+              errors: [
+                expect.objectContaining({
+                  message: 'You do not have permission to perform this action',
+                  status_code: 403,
+                  rules: [{ id: 'mocked' }],
+                }),
+                expect.objectContaining({
+                  message: 'User error',
+                  status_code: 400,
+                  rules: [{ id: 'mocked2' }],
+                }),
+              ],
+            }),
+          }),
+          statusCode: 403,
+        })
+      );
+    });
+
+    it('responds with the highest status code if there are multiple errors of different tiers of status codes', () => {
+      buildBulkResponse(mockResponseFactory, {
+        bulkAction: BulkActionTypeEnum.duplicate,
+        isDryRun: false,
+        errors: [
+          {
+            item: 'mocked',
+            error: Boom.forbidden('You do not have permission to perform this action'),
+          },
+          {
+            item: 'mocked2',
+            error: Boom.internal('Something went wrong'),
+          },
+        ],
+        updated: [],
+        created: [],
+        deleted: [],
+        skipped: [],
+      });
+
+      expect(mockResponseFactory.custom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            message: 'Bulk edit failed',
+            status_code: 500,
+            attributes: expect.objectContaining({
+              errors: [
+                expect.objectContaining({
+                  message: 'You do not have permission to perform this action',
+                  status_code: 403,
+                  rules: [{ id: 'mocked' }],
+                }),
+                expect.objectContaining({
+                  message: 'An internal server error occurred',
+                  status_code: 500,
+                  rules: [{ id: 'mocked2' }],
+                }),
+              ],
+            }),
+          }),
+          statusCode: 500,
+        })
+      );
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_schedule_rule_gap_filling.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_schedule_rule_gap_filling.ts
@@ -88,12 +88,7 @@ export const bulkScheduleRuleGapFilling = async ({
     }
   );
 
-  errored.forEach((backfillingError) => {
-    errors.push({
-      ...backfillingError,
-      message: `${backfillingError.step} - ${backfillingError.message}`,
-    });
-  });
+  errors.push(...errored);
 
   const rulesDict = keyBy(validatedRules, 'id');
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_schedule_rule_gap_filling.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_schedule_rule_gap_filling.ts
@@ -90,8 +90,8 @@ export const bulkScheduleRuleGapFilling = async ({
 
   errored.forEach((backfillingError) => {
     errors.push({
-      rule: backfillingError.rule,
-      message: `${backfillingError.step} - ${backfillingError.errorMessage}`,
+      ...backfillingError,
+      message: `${backfillingError.step} - ${backfillingError.message}`,
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -38,7 +38,7 @@ import {
 } from '../../../logic/bulk_actions/validations';
 import { getExportByObjectIds } from '../../../logic/export/get_export_by_object_ids';
 import { RULE_MANAGEMENT_BULK_ACTION_SOCKET_TIMEOUT_MS } from '../../timeouts';
-import type { BulkActionError } from './bulk_actions_response';
+import type { BulkActionError } from './utils';
 import { buildBulkResponse } from './bulk_actions_response';
 import { bulkEnableDisableRules } from './bulk_enable_disable_rules';
 import { fetchRulesByQueryOrIds } from './fetch_rules_by_query_or_ids';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/utils.ts
@@ -7,8 +7,15 @@
 
 import type { ScheduleBackfillResults } from '@kbn/alerting-plugin/server/application/backfill/methods/schedule/types';
 import type { BulkOperationError } from '@kbn/alerting-plugin/server';
+import { transformError } from '@kbn/securitysolution-es-utils';
+import type { RuleDetailsInError } from '../../../../../../../common/api/detection_engine';
+import type {
+  BulkActionsDryRunErrCode,
+  NormalizedRuleError,
+} from '../../../../../../../common/api/detection_engine/rule_management';
 import type { PromisePoolError } from '../../../../../../utils/promise_pool';
 import type { RuleAlertType } from '../../../../rule_schema';
+import type { DryRunError } from '../../../logic/bulk_actions/dry_run';
 
 interface HandleScheduleBackfillResultsParams {
   rules: RuleAlertType[];
@@ -47,4 +54,45 @@ export const handleScheduleBackfillResults = ({
     },
     { backfilled: [], errors } as HandleScheduleBackfillResultsOutcome
   );
+};
+
+export type BulkActionError =
+  | PromisePoolError<string>
+  | PromisePoolError<RuleAlertType>
+  | BulkOperationError;
+
+/**
+ * Normalize different error types (PromisePoolError<string> | PromisePoolError<RuleAlertType> | BulkOperationError)
+ * to one common used in NormalizedRuleError
+ * @param error BulkActionError
+ */
+export const normalizeBulkActionError = (errorObj: BulkActionError): NormalizedRuleError => {
+  let message: string;
+  let statusCode: number = 500;
+  let errorCode: BulkActionsDryRunErrCode | undefined;
+  let rule: RuleDetailsInError;
+
+  if ('rule' in errorObj) {
+    rule = errorObj.rule;
+    message = errorObj.message;
+  } else {
+    const { error, item } = errorObj;
+    const transformedError =
+      error instanceof Error ? transformError(error) : { message: String(error), statusCode: 500 };
+
+    errorCode = (error as DryRunError)?.errorCode;
+    message = transformedError.message;
+    statusCode = transformedError.statusCode;
+    // The promise pool item is either a rule ID string or a rule object. We have
+    // string IDs when we fail to fetch rules. Rule objects come from other
+    // situations when we found a rule but failed somewhere else.
+    rule = typeof item === 'string' ? { id: item } : { id: item.id, name: item.name };
+  }
+
+  return {
+    message,
+    status_code: statusCode,
+    err_code: errorCode,
+    rules: [rule],
+  };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/utils.ts
@@ -75,6 +75,7 @@ export const normalizeBulkActionError = (errorObj: BulkActionError): NormalizedR
   if ('rule' in errorObj) {
     rule = errorObj.rule;
     message = errorObj.message;
+    statusCode = errorObj.status ?? 500;
   } else {
     const { error, item } = errorObj;
     const transformedError =

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/utils/utils.ts
@@ -29,7 +29,7 @@ import { createBulkErrorObject } from '../../routes/utils';
 import type { InvestigationFieldsCombined, RuleAlertType, RuleParams } from '../../rule_schema';
 import { hasValidRuleType } from '../../rule_schema';
 import { internalRuleToAPIResponse } from '../logic/detection_rules_client/converters/internal_rule_to_api_response';
-import type { BulkActionError } from '../api/rules/bulk_actions/bulk_actions_response';
+import type { BulkActionError } from '../api/rules/bulk_actions/utils';
 
 type PromiseFromStreams = RuleToImport | Error;
 const MAX_CONCURRENT_SEARCHES = 10;

--- a/x-pack/solutions/security/test/security_solution_api_integration/config/privileges/roles.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/config/privileges/roles.ts
@@ -224,3 +224,72 @@ export const roles: Role[] = [
   secReadV1,
   secNoneV1,
 ];
+
+export const rulesRead: Role = {
+  name: 'rules:read',
+  privileges: {
+    elasticsearch: {
+      indices: [
+        {
+          names: [
+            '.alerts-security.alerts-default',
+            '.internal.alerts-security.alerts-default-*',
+            '.siem-signals-default',
+            '.lists-default',
+            '.items-default',
+          ],
+          privileges: ['maintenance', 'write', 'read', 'view_index_metadata'],
+        },
+      ],
+    },
+    kibana: [
+      {
+        feature: {
+          indexPatterns: ['all'],
+          securitySolutionRulesV1: ['read'],
+          savedObjectsManagement: ['all'],
+        },
+        spaces: ['*'],
+      },
+    ],
+  },
+};
+
+export const rulesAll: Role = {
+  name: 'rules:all',
+  privileges: {
+    elasticsearch: {
+      indices: [
+        {
+          names: [
+            '.alerts-security.alerts-default',
+            '.internal.alerts-security.alerts-default-*',
+            '.siem-signals-default',
+            '.lists-default',
+            '.items-default',
+          ],
+          privileges: ['manage', 'write', 'read', 'view_index_metadata'],
+        },
+        {
+          names: [
+            '.preview.alerts-security.alerts-default',
+            '.internal.preview.alerts-security.alerts-default-*',
+          ],
+          privileges: ['read'],
+        },
+      ],
+    },
+    kibana: [
+      {
+        feature: {
+          indexPatterns: ['all'],
+          siemv5: ['all'],
+          actions: ['all'],
+          securitySolutionRulesV1: ['all'],
+          savedObjectsManagement: ['all'],
+        },
+        spaces: ['*'],
+      },
+    ],
+  },
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/bulk_actions_rbac.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/bulk_actions_rbac.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
 import expect from 'expect';
 
@@ -23,8 +24,8 @@ export default ({ getService }: FtrProviderContextWithSpaces) => {
 
   describe.only('@ess @serverless @skipInServerlessMKI Rules RBAC - Bulk Actions APIs', () => {
     let ruleId: string;
-    let rulesReadApis: ReturnType<typeof detectionsApi.createScopedApiInstance>;
-    let rulesAllApis: ReturnType<typeof detectionsApi.createScopedApiInstance>;
+    let rulesReadApis: ReturnType<typeof detectionsApi.withUser>;
+    let rulesAllApis: ReturnType<typeof detectionsApi.withUser>;
 
     beforeEach(async () => {
       await deleteAllRules(supertest, log);
@@ -53,10 +54,8 @@ export default ({ getService }: FtrProviderContextWithSpaces) => {
         await Promise.all([utils.createUser(rulesReadUser), utils.createUser(rulesAllUser)]);
       }
 
-      const rulesReadSupertest = await utils.createSuperTestWithUser(rulesReadUser);
-      const rulesAllSupertest = await utils.createSuperTestWithUser(rulesAllUser);
-      rulesReadApis = detectionsApi.createScopedApiInstance(rulesReadSupertest);
-      rulesAllApis = detectionsApi.createScopedApiInstance(rulesAllSupertest);
+      rulesReadApis = detectionsApi.withUser(rulesReadUser);
+      rulesAllApis = detectionsApi.withUser(rulesAllUser);
     });
 
     afterEach(async () => {
@@ -65,34 +64,242 @@ export default ({ getService }: FtrProviderContextWithSpaces) => {
 
     describe('duplicating rules', () => {
       it('allows a user with the "rules:all" feature to bulk duplicate rules', async () => {
-        const bulkDuplicateResponse = await rulesAllApis.performRulesBulkAction({
-          query: {},
-          body: {
-            ids: [ruleId],
-            action: BulkActionTypeEnum.duplicate,
-          },
-        });
+        const { body: responseBody, status: responseStatus } =
+          await rulesAllApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.duplicate,
+            },
+          });
 
-        expect(bulkDuplicateResponse).toEqual(expect.objectContaining({ status: 200 }));
+        expect(responseStatus).toEqual(200);
+        expect(responseBody).toEqual(expect.objectContaining({ rules_count: 1, success: true }));
       });
 
-      it('rejects a user with the "rules:read" feature to bulk duplicate rules', async () => {
-        const bulkDuplicateResponse = await rulesReadApis.performRulesBulkAction({
-          query: {},
-          body: {
-            ids: [ruleId],
-            action: BulkActionTypeEnum.duplicate,
-          },
-        });
+      it('rejects a user with the "rules:read" feature trying to bulk duplicate rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesReadApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.duplicate,
+            },
+          });
 
-        expect(bulkDuplicateResponse).toEqual(expect.objectContaining({ status: 403 }));
+        expect(responseStatus).toEqual(403);
+        expect(responseBody.attributes.errors).toHaveLength(1);
+        expect(responseBody.attributes.errors[0]).toEqual(
+          expect.objectContaining({
+            message: expect.stringMatching(/unauthorized/i),
+            rules: [expect.objectContaining({ id: ruleId })],
+          })
+        );
       });
     });
 
-    describe('editing rules', () => {});
-    describe('deleting rules', () => {});
-    describe('exporting rules', () => {});
-    describe('enabling/disabling rules', () => {});
-    describe('filling rule gaps', () => {});
+    describe('editing rules', () => {
+      it('allows a user with the "rules:all" feature to bulk edit rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesAllApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.edit,
+              edit: [
+                {
+                  type: 'add_tags',
+                  value: ['newTag'],
+                },
+              ],
+            },
+          });
+
+        expect(responseStatus).toEqual(200);
+        expect(responseBody).toEqual(expect.objectContaining({ rules_count: 1, success: true }));
+      });
+
+      it('rejects a user with the "rules:read" feature trying to bulk edit rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesReadApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.edit,
+              edit: [
+                {
+                  type: 'add_tags',
+                  value: ['newTag'],
+                },
+              ],
+            },
+          });
+
+        expect(responseStatus).toEqual(403);
+        expect(responseBody).toEqual(
+          expect.objectContaining({
+            message: expect.stringMatching(/unauthorized/i),
+          })
+        );
+      });
+    });
+
+    describe('deleting rules', () => {
+      it('allows a user with the "rules:all" feature to bulk delete rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesAllApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.delete,
+            },
+          });
+
+        expect(responseStatus).toEqual(200);
+        expect(responseBody).toEqual(expect.objectContaining({ rules_count: 1, success: true }));
+      });
+
+      it('rejects a user with the "rules:read" feature trying to bulk delete rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesReadApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.delete,
+            },
+          });
+
+        expect(responseStatus).toEqual(403);
+        expect(responseStatus).toEqual(403);
+        expect(responseBody.attributes.errors).toHaveLength(1);
+        expect(responseBody.attributes.errors[0]).toEqual(
+          expect.objectContaining({
+            message: expect.stringMatching(/unauthorized/i),
+            rules: [expect.objectContaining({ id: ruleId })],
+          })
+        );
+      });
+    });
+
+    describe('exporting rules', () => {
+      it('allows a user with the "rules:all" feature to bulk export rules', async () => {
+        const { headers: responseHeaders, status: responseStatus } =
+          await rulesAllApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.export,
+            },
+          });
+
+        expect(responseStatus).toEqual(200);
+        expect(responseHeaders['content-disposition']).toContain('attachment');
+      });
+
+      it('allows a user with the "rules:read" feature to bulk export rules', async () => {
+        const { headers: responseHeaders, status: responseStatus } =
+          await rulesReadApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.export,
+            },
+          });
+
+        expect(responseStatus).toEqual(200);
+        expect(responseHeaders['content-disposition']).toContain('attachment');
+      });
+    });
+
+    describe('enabling/disabling rules', () => {
+      it('allows a user with the "rules:all" feature to bulk enable rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesAllApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.enable,
+            },
+          });
+
+        expect(responseStatus).toEqual(200);
+        expect(responseBody).toEqual(expect.objectContaining({ rules_count: 1, success: true }));
+      });
+
+      it('rejects a user with the "rules:read" feature trying to bulk enable rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesReadApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.enable,
+            },
+          });
+
+        expect(responseStatus).toEqual(403);
+        expect(responseBody).toEqual(
+          expect.objectContaining({
+            message: expect.stringMatching(/unauthorized/i),
+          })
+        );
+      });
+    });
+
+    describe('filling rule gaps', () => {
+      beforeEach(async () => {
+        // you can only fill on an enabled rule, which our default rule is not
+        const resp = await createRule(
+          supertest,
+          log,
+          getCustomQueryRuleParams({
+            rule_id: uuidv4(),
+            enabled: true,
+          })
+        );
+        ruleId = resp.id;
+      });
+
+      it('allows a user with the "rules:all" feature to bulk fill gaps for rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesAllApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.fill_gaps,
+              [BulkActionTypeEnum.fill_gaps]: {
+                start_date: moment().subtract(2, 'hours').toISOString(),
+                end_date: moment().toISOString(),
+              },
+            },
+          });
+
+        expect(responseStatus).toEqual(200);
+        expect(responseBody).toEqual(expect.objectContaining({ rules_count: 1, success: true }));
+      });
+
+      it('rejects a user with the "rules:read" feature trying to bulk fill gaps for rules', async () => {
+        const { body: responseBody, status: responseStatus } =
+          await rulesReadApis.performRulesBulkAction({
+            query: {},
+            body: {
+              ids: [ruleId],
+              action: BulkActionTypeEnum.fill_gaps,
+              [BulkActionTypeEnum.fill_gaps]: {
+                start_date: moment().subtract(2, 'hours').toISOString(),
+                end_date: moment().toISOString(),
+              },
+            },
+          });
+
+        expect(responseStatus).toEqual(403);
+        expect(responseBody.attributes.errors).toHaveLength(1);
+        expect(responseBody.attributes.errors[0]).toEqual(
+          expect.objectContaining({
+            message: expect.stringMatching(/unauthorized/i),
+            rules: [expect.objectContaining({ id: ruleId })],
+          })
+        );
+      });
+    });
   });
 };

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/bulk_actions_rbac.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/bulk_actions_rbac.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import expect from 'expect';
+
+import { BulkActionTypeEnum } from '@kbn/security-solution-plugin/common/api/detection_engine';
+import type { FtrProviderContextWithSpaces } from '../../../../../ftr_provider_context_with_spaces';
+import { createRule, deleteAllRules } from '../../../../../config/services/detections_response';
+import { getCustomQueryRuleParams } from '../../../utils';
+import { rulesAll, rulesRead } from '../../../../../config/privileges/roles';
+
+export default ({ getService }: FtrProviderContextWithSpaces) => {
+  const supertest = getService('supertest');
+  const detectionsApi = getService('detectionsApi');
+  const log = getService('log');
+  const utils = getService('securitySolutionUtils');
+  const isEss = !getService('config').get('serverless');
+
+  describe.only('@ess @serverless @skipInServerlessMKI Rules RBAC - Bulk Actions APIs', () => {
+    let ruleId: string;
+    let rulesReadApis: ReturnType<typeof detectionsApi.createScopedApiInstance>;
+    let rulesAllApis: ReturnType<typeof detectionsApi.createScopedApiInstance>;
+
+    beforeEach(async () => {
+      await deleteAllRules(supertest, log);
+      const resp = await createRule(
+        supertest,
+        log,
+        getCustomQueryRuleParams({
+          rule_id: uuidv4(),
+        })
+      );
+      ruleId = resp.id;
+
+      const rulesReadUser = {
+        username: 'rules_read',
+        password: 'password',
+        roles: [rulesRead.name],
+      };
+      const rulesAllUser = { username: 'rules_all', password: 'password', roles: [rulesAll.name] };
+
+      // create rules roles
+      if (isEss) {
+        await Promise.all([
+          utils.createRole(rulesRead.name, rulesRead),
+          utils.createRole(rulesAll.name, rulesAll),
+        ]);
+        await Promise.all([utils.createUser(rulesReadUser), utils.createUser(rulesAllUser)]);
+      }
+
+      const rulesReadSupertest = await utils.createSuperTestWithUser(rulesReadUser);
+      const rulesAllSupertest = await utils.createSuperTestWithUser(rulesAllUser);
+      rulesReadApis = detectionsApi.createScopedApiInstance(rulesReadSupertest);
+      rulesAllApis = detectionsApi.createScopedApiInstance(rulesAllSupertest);
+    });
+
+    afterEach(async () => {
+      await deleteAllRules(supertest, log);
+    });
+
+    describe('duplicating rules', () => {
+      it('allows a user with the "rules:all" feature to bulk duplicate rules', async () => {
+        const bulkDuplicateResponse = await rulesAllApis.performRulesBulkAction({
+          query: {},
+          body: {
+            ids: [ruleId],
+            action: BulkActionTypeEnum.duplicate,
+          },
+        });
+
+        expect(bulkDuplicateResponse).toEqual(expect.objectContaining({ status: 200 }));
+      });
+
+      it('rejects a user with the "rules:read" feature to bulk duplicate rules', async () => {
+        const bulkDuplicateResponse = await rulesReadApis.performRulesBulkAction({
+          query: {},
+          body: {
+            ids: [ruleId],
+            action: BulkActionTypeEnum.duplicate,
+          },
+        });
+
+        expect(bulkDuplicateResponse).toEqual(expect.objectContaining({ status: 403 }));
+      });
+    });
+
+    describe('editing rules', () => {});
+    describe('deleting rules', () => {});
+    describe('exporting rules', () => {});
+    describe('enabling/disabling rules', () => {});
+    describe('filling rule gaps', () => {});
+  });
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/index.ts
@@ -9,6 +9,7 @@ import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Rules Management - Rule Bulk Action API', function () {
+    loadTestFile(require.resolve('./bulk_actions_rbac'));
     loadTestFile(require.resolve('./perform_bulk_action_dry_run'));
     loadTestFile(require.resolve('./perform_bulk_action_dry_run_ess'));
     loadTestFile(require.resolve('./perform_bulk_action'));


### PR DESCRIPTION
### Note: Do not merge
This work is part of a larger effort to enable bulk actions for `rules:read` users. As this will require some frontend changes and additional QA, I am opting to leave this in draft while we finish out the initial RBAC work itself.

## Summary

Whenever an error of any kind was encountered in these APIs, a 500 response would be returned.  With the work being performed in the [Rules RBAC]() effort, we have now relaxed the API authorization of these APIs to allow either `rules:read` or `rules:all`, but as such we need to ensure that correct/useful errors are returned from these APIs (which power many rules management/detection engine workflows) so that users can properly diagnose their issue.

In this case, we are focusing on authorization errors, and the behavior/tests added here center around the fact of 403s being returned in cases where the user is not authorized for the given action.



## How to review
~I've mainly opened this PR for clarity's sake while I await review on the [test code on which this work depends](https://github.com/elastic/kibana/pull/241909). Since this branch _also_ contains that code, a diff without that noise can be seen [HERE](https://github.com/rylnd/kibana/compare/65a166c6403c6bcd18c38a3a43829f1939aca315...rules-rbac-with-scoping).~

Please take a look and add any comments, but once https://github.com/elastic/kibana/pull/241909 is merged, I'm going to merge this PR directly to the main rbac branch, `rules-rbac-new`, where it can be tested/reviewed as a whole.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



